### PR TITLE
Add dockerfile support, Fix various DDR Genie bugs

### DIFF
--- a/DDRBot.py
+++ b/DDRBot.py
@@ -1243,9 +1243,7 @@ class DDRBotClient(discord.Client):
                     await self.db_add_queue.put(
                         DBTaskWorkItem(message.author.id, '%s-%s.jpg' % (photo['game_name'], photo['last_play_date']),
                                        photo['last_play_date'], game='iidx'))
-            else:
-                print("DDRGenie is not enabled so screenshot parsing is unavailiable")
-         
+
         if len(screenshot_files) > 10:
             screenshot_files = divide_chunks(screenshot_files, 10)
             await message.channel.send("Your screenshots since last check:")

--- a/DDRBot.py
+++ b/DDRBot.py
@@ -1236,12 +1236,16 @@ class DDRBotClient(discord.Client):
             data = eal.get_jpeg_data_for(photo['file_path'])
             screenshot_files.append(discord.File(io.BytesIO(data), '%s-%s.jpg' % ((photo['game_name'], photo['last_play_date']))))
             archive_screenshot(message.author.id, '%s-%s.jpg' % (photo['game_name'], photo['last_play_date']), data)
-            if 'dance' in photo['game_name'].lower():
-                await self.db_add_queue.put(DBTaskWorkItem(message.author.id, '%s-%s.jpg' % (photo['game_name'], photo['last_play_date']), photo['last_play_date']))
-            if 'beatmania' in photo['game_name'].lower():
-                await self.db_add_queue.put(
-                    DBTaskWorkItem(message.author.id, '%s-%s.jpg' % (photo['game_name'], photo['last_play_date']),
-                                   photo['last_play_date'], game='iidx'))
+            if os.path.exists("DDR_GENIE_ON"):
+                if 'dance' in photo['game_name'].lower():
+                    await self.db_add_queue.put(DBTaskWorkItem(message.author.id, '%s-%s.jpg' % (photo['game_name'], photo['last_play_date']), photo['last_play_date']))
+                if 'beatmania' in photo['game_name'].lower():
+                    await self.db_add_queue.put(
+                        DBTaskWorkItem(message.author.id, '%s-%s.jpg' % (photo['game_name'], photo['last_play_date']),
+                                       photo['last_play_date'], game='iidx'))
+            else:
+                print("DDRGenie is not enabled so screenshot parsing is unavailiable")
+         
         if len(screenshot_files) > 10:
             screenshot_files = divide_chunks(screenshot_files, 10)
             await message.channel.send("Your screenshots since last check:")

--- a/DDRBot.py
+++ b/DDRBot.py
@@ -390,7 +390,7 @@ class DDRBotClient(discord.Client):
             self.loop.create_task(self.gstats_task())
             self.gstats_task_created = True
             print("[TASK] Created gstats thread")
-        if not self.db_task_started:
+        if not self.db_task_started and os.path.exists("DDR_GENIE_ON"):
             self.loop.create_task(self.db_task())
             self.db_task_started = True
             print("[TASK] Created DB task")

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN pip3 install -r Requirements.txt
 RUN cd DDRGenie && pip3 install -r Requirements.txt
 RUN touch DDR_GENIE_ON
 
+#Set user folder permissions
+RUN chown -R bot_user:bot_user /home/bot_user
+
 #Switch to bot_user
 USER bot_user
 RUN ls -l ~/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:buster-slim
+
+#Setup a generic user
+RUN useradd -ms /bin/bash bot_user
+USER root
+
+#Copy our app to a local folder
+COPY . /home/bot_user/app
+WORKDIR /home/bot_user/app
+
+#Update debian and install pip
+RUN apt-get update -y && apt-get install apt-utils -y
+RUN apt-get install python3 python3-pip git -y
+
+#Update sub-modules
+RUN cd DDRGenie && git submodule init && git submodule update
+
+#Install required dependencies
+RUN pip3 install pillow
+RUN pip3 install -r Requirements.txt
+
+#Install sub-module dependencies
+RUN cd DDRGenie && pip3 install -r Requirements.txt
+RUN touch DDR_GENIE_ON
+
+#Switch to bot_user
+USER bot_user
+RUN ls -l ~/app
+
+#Run bot
+ENTRYPOINT ["python3", "DDRBot.py"]

--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,15 @@ This is a python-based bot to assist in providing various information about DDR 
 ## Running
 ```
 pip install -r Requirements.txt
-python DDRBot.py [bot token] [m573ssid]
+python DDRBot.py [discord bot token] [m573ssid cookie value]
 ```
+
+## Docker
+```
+docker build . -t ddrbot
+docker run -it ddrbot [discord bot token] [m573ssid cookie value]
+```
+
 ## Features
 * Arcade Monitoring (Last played reporting)
 * E-Amusement Screenshot Scraping


### PR DESCRIPTION
This PR does the following:
- Adds a `Dockerfile` for image building
- Adds a related Docker entry to the `README`
- Fixes a bug where the `DBTaskWorkItem` is requested even though DDR Genie was not enabled
- Fixes a bug where the `db` class is requested even though DDR Genie was not enabled